### PR TITLE
feat(build): github action using game ci to build game in webgl format and then deploy to heroku

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -44,7 +44,9 @@ jobs:
           path: build
 
       - name: Deploy 🚀
-        uses: JamesIves/github-pages-deploy-action@v4.3.3
+        uses: akhileshns/heroku-deploy@v3.12.12
         with:
-          branch: gh-pages
-          folder: build
+          heroku_api_key: ${{secrets.HEROKU_API_KEY}}
+          heroku_app_name: "cloud-runner"
+          heroku_email: "steph.sprinkle@tuta.io"
+          appdir: "build"


### PR DESCRIPTION
Github action to build and deploy the game! Build uses [GameCI](https://game.ci/docs/github/getting-started#workflow-examples) and the deployment is to [Heroku](https://github.com/marketplace/actions/deploy-to-heroku) on push to `main`.

@rauldel The necessary secrets will need to be added and Github pages configured. Both are under the Settings tab. The Heroku action "deploys" the `build` folder.

