### PR TITLE
feat(build): deploy webgl build to github pages

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -38,17 +38,11 @@ jobs:
           UNITY_PASSWORD: ${{ secrets.UNITY_PASSWORD }}
         with:
           targetPlatform: WebGL
+          unityVersion: 2019.4.39f1
           allowDirtyBuild: true
 
-      - uses: actions/upload-artifact@v2
-        with:
-          name: Build
-          path: build
-
       - name: Deploy 🚀
-        uses: akhileshns/heroku-deploy@v3.12.12
+        uses: JamesIves/github-pages-deploy-action@4.1.3
         with:
-          args: deploy --dir=build
-          heroku_api_key: ${{secrets.HEROKU_API_KEY}}
-          heroku_app_name: "cloud-runner"
-          heroku_email: "steph.sprinkle@tuta.io"
+          branch: gh-pages
+          folder: build/WebGL/WebGL


### PR DESCRIPTION
Modified deploy step to use Github pages. Based loosely on [this example](https://refactoring.ninja/posts/2021-07-15-publishing-a-unity-webgl-game-from-scratch-in-under-30-minutes/#create-deploy-github-action).

I'll set up Github pages once the repository goes public!